### PR TITLE
fix nokeepreal to not keepreal

### DIFF
--- a/cryodrgn/commands/preprocess.py
+++ b/cryodrgn/commands/preprocess.py
@@ -65,7 +65,7 @@ def main(args):
     window = args.window
     invert_data = args.invert_data
     downsample = (args.D and args.D < original_D)
-    nokeepreal = args.keepreal
+    nokeepreal = not args.keepreal
     log(f'keepreal {args.keepreal}')
     log(f'lazy {args.lazy}')
     log(f'invert_data {args.invert_data}')


### PR DESCRIPTION
**Describe the bug**
Running preprocessing without --no-keep-real makes particles with 65 pixels instead of 64, and then train_cv with encode_mode 'conv' for opusDSD complains that the pixel size isn't even.
```
Traceback (most recent call last):
  File "/home/jkrieger/software/miniconda/envs/opusdsd-0.3.2b/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/jkrieger/software/miniconda/envs/opusdsd-0.3.2b/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/jkrieger/software/scipion3/software/em/opusdsd-0.3.2b/cryodrgn/commands/train_cv.py", line 1157, in <module>
    main(args)
  File "/home/jkrieger/software/scipion3/software/em/opusdsd-0.3.2b/cryodrgn/commands/train_cv.py", line 725, in main
    data = dataset.LazyMRCData(args.particles, norm=args.norm,
  File "/home/jkrieger/software/scipion3/software/em/opusdsd-0.3.2b/cryodrgn/dataset.py", line 51, in __init__
    assert ny % 2 == 0, "Image size must be even"
AssertionError: Image size must be even
```
Looking at the particles in Python confirms the problem:
```
In [1]: particles='/home/jkrieger/ScipionUserData/projects/TestOpusDsd/Runs/000186_OpusDsdProtPreprocess/output_particles/particles.64.ft.txt'

In [2]: from cryodrgn import dataset
Installed qt5 event loop hook.

In [3]: norm=None

In [4]: real_data=True

In [5]: invert_data=True

In [6]: ind=None

In [7]: use_real=True

In [8]: window=False

In [9]: relion31=True

In [10]: data=None

In [11]: datadir=None

In [12]: window_r=.85

In [13]: in_mem=True

In [14]: notinmem=False

In [15]:             data = dataset.LazyMRCData(particles, norm=norm,
    ...:                                        real_data=real_data, invert_data=invert_data,
    ...:                                        ind=ind, keepreal=use_real, window=False,
    ...:                                        datadir=datadir, relion31=relion31, window_r=window_r, in_mem=(not notinmem))
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In[15], line 1
----> 1 data = dataset.LazyMRCData(particles, norm=norm,
      2                            real_data=real_data, invert_data=invert_data,
      3                            ind=ind, keepreal=use_real, window=False,
      4                            datadir=datadir, relion31=relion31, window_r=window_r, in_mem=(not notinmem))

File ~/software/scipion3/software/em/opusdsd-0.3.2b/cryodrgn/dataset.py:51, in LazyMRCData.__init__(self, mrcfile, norm, real_data, keepreal, invert_data, ind, window, datadir, relion31, window_r, in_mem)
     49 ny, nx = particles[0].get().shape
     50 assert ny == nx, "Images must be square"
---> 51 assert ny % 2 == 0, "Image size must be even"
     52 log('Loaded {} {}x{} images'.format(N, ny, nx))
     53 self.particles = particles

AssertionError: Image size must be even

In [18]: mrcfile=particles

In [19]: particles = dataset.load_particles(mrcfile, True, datadir=datadir, relion31=relion31)

In [20]: type(particles)
Out[20]: list

In [21]:         N = len(particles)
    ...:         ny, nx = particles[0].get().shape

In [22]: ny
Out[22]: 65

In [23]: nx
Out[23]: 65
```

**To Reproduce**
```
CUDA_VISIBLE_DEVICES=0
python -m cryodrgn.commands.preprocess Runs/000186_OpusDsdProtPreprocess/extra/input_particles.star  -o Runs/000186_OpusDsdProtPreprocess/output_particles/particles.64.mrcs  -D 64 --window-r 0.85 --max-threads 16  --relion31  -b 5000
python -m cryodrgn.commands.parse_pose_star Runs/000186_OpusDsdProtPreprocess/extra/input_particles.star  -o Runs/000186_OpusDsdProtPreprocess/output_particles/poses.pkl  --relion31  -D 64  --Apix 3.54
python -m cryodrgn.commands.parse_pose_star Runs/000186_OpusDsdProtPreprocess/extra/input_particles.star  -o Runs/000186_OpusDsdProtPreprocess/output_particles/poses.pkl  --relion31  -D 64  --Apix 3.54
python -m cryodrgn.commands.parse_ctf_star Runs/000186_OpusDsdProtPreprocess/extra/input_particles.star  -o Runs/000186_OpusDsdProtPreprocess/output_particles/ctfs.pkl  --relion31  -D 64  --Apix 3.54  --kv 300.0  --cs 2.7  -w 0.1  --ps 0
python -m cryodrgn.commands.train_cv Runs/000186_OpusDsdProtPreprocess/output_particles/particles.64.ft.txt --poses Runs/000186_OpusDsdProtPreprocess/output_particles/poses.pkl --ctf Runs/000186_OpusDsdProtPreprocess/output_particles/ctfs.pkl --zdim 2 -o Runs/000237_OpusDsdProtTrain/output  -n 3 --preprocessed --max-threads 1  --enc-layers 3 --enc-dim 1024 --dec-layers 3 --dec-dim 1024 --lazy-single  --pe-type vanilla  --encode-mode grad  --template-type conv  -b 5000 --lr 0.00012  --beta-control 1.0  --beta cos  --downfrac 0.5  --valfrac 0.2  --lamb 1.0  --bfactor 4.0  --templateres 192
```

**Expected behavior**
The particles should be of size 64 x 64 pixels if --no-keep-real isn't set and then train_cv runs passed this point. This happens with the fix.

**Additional context**
- You should probably know that I am making a plugin for opusDSD within the Scipion workflow engine, which can be found at https://github.com/scipion-em/scipion-em-opusdsd. This allows opusDSD to be run from a GUI and included in pipelines. If you would like to meet and see what I'm doing and be involved, you are very welcome to.
- These results are from using the test dataset that was also used for CryoDRGN, which comes from a refinement in a Relion tutorial dataset and contains 1799 particles.
