### PR TITLE
remove limit to 128

### DIFF
--- a/cryodrgn/commands/train_cv.py
+++ b/cryodrgn/commands/train_cv.py
@@ -945,7 +945,6 @@ def main(args):
     data_generator = DataLoader(data, batch_sampler=train_sampler)
     val_data_generator = DataLoader(data, batch_sampler=val_sampler)
 
-    assert args.downfrac*(D-1) >= 128
     log(f'image will be downsampled to {args.downfrac} of original size {D-1}')
     log(f'reconstruction will be blurred by bfactor {args.bfactor}')
 


### PR DESCRIPTION
This acts upon the following:
     https://github.com/alncat/opusDSD/blob/86bed17a235c3a166ca03b51aa75963a3f81c63e/cryodrgn/commands/train_cv.py#L948 This line can be deleted since this size limit no longer holds. The intermediate tensors will be resampled to 12^3 in encoder, https://github.com/alncat/opusDSD/blob/86bed17a235c3a166ca03b51aa75963a3f81c63e/cryodrgn/models.py#L663 . Hence, the encoder works with any size now 😺. You can try to delete that line and test on 64x64 images. It will be great if we can control the number of layers, but this requires us to refactor the encoder and convtemplate classes ( this will make the code more readable btw).

_Originally posted by @alncat in https://github.com/alncat/opusDSD/issues/5#issuecomment-1818983866_
            